### PR TITLE
[HighlightCommon] Several improvements (undo transaction, grouping, ...)

### DIFF
--- a/Utility/HighlightCommon.FCMacro
+++ b/Utility/HighlightCommon.FCMacro
@@ -5,8 +5,8 @@ from __future__ import unicode_literals
 __Name__ = 'Highlight Common parts'
 __Comment__ = 'Compute the common parts between selected shapes'
 __Author__ = 'JMG, galou and other contributors'
-__Version__ = '2.1.0'
-__Date__ = '2020-01-25'
+__Version__ = '2.2.0'
+__Date__ = '2020-03-29'
 __License__ = 'CC0-1.0'
 __Web__ = 'https://freecadweb.org/wiki/Macro_HighlightCommon'
 __Wiki__ = 'https://freecadweb.org/wiki/Macro_HighlightCommon'
@@ -27,54 +27,95 @@ except ImportError:
 import FreeCAD as app
 import FreeCADGui as gui
 
-
-def error_dialog(msg):
-    """Create a simple dialog QMessageBox with an error message."""
-    app.Console.PrintError(msg + '\n')
-    diag = QMessageBox(QMessageBox.Icon.Critical,
-                       'Error in macro HighlightCommon',
-                       msg)
-    diag.setWindowModality(QtCore.Qt.ApplicationModal)
-    diag.exec_()
-
-
 def main():
+
+    # Return with error if less than 2 objects selected
     if len(gui.Selection.getSelection()) < 2:
-        error_dialog('Select at least two objects')
+        app.Console.PrintError('Select at least two objects\n')
+        QMessageBox(QMessageBox.Icon.Critical,
+            'Error in macro HighlightCommon',
+            'Select at least two objects').exec_()
         return
 
+    # store active doc in case it may change during run
+    doc = App.ActiveDocument
+    colli_grp = None # Group object to group collisions
+    colli_max = 0 # Maximum collision volume
+    # open a transaction in undo pile
+    doc.openTransaction("Seeking collisions")
+
+    # ensure list of unique objects
     object_list = []
     for obj in gui.Selection.getSelection():
         if obj not in object_list:
             object_list.append(obj)
 
+    # going through selected objects (object A)
     for i, object_a in enumerate(object_list):
+        shape_a = object_a.Shape
+        label_a = object_a.Label
+        # if object A has no volume (eg. a sketch)
+        # just skip it with information to user
+        if shape_a.Volume < 1e-6:
+            app.Console.PrintMessage(
+                '{} has no volume ... skipping'.format(
+                    label_a))
+            continue
+        # making selected objects transparent
+        # comment this line if you don't want it
+        object_a.ViewObject.Transparency = 80
+
+        # comparing object A with all
+        # following ones in the list (object B)
         for object_b in object_list[(i + 1):]:
-            shape_a = object_a.Shape
             shape_b = object_b.Shape
-            label_a = object_a.Label
             label_b = object_b.Label
+            # skip object B is it has no volume
+            # no need to warn as it has been
+            # already done as object A
+            if shape_b.Volume < 1e-6:
+                continue
             common = shape_a.common(shape_b)
+
+            # if object A & object B have a collision
+            # display message with collision volume
+            # add a new representative shape in the group
             if common.Volume > 1e-6:
                 app.Console.PrintMessage(
-                    'Volume of the intersection between {} and {}: {}\n'.format(
+                    'Volume of the intersection between {} and {} : {} mm3\n'.format(
                         label_a,
                         label_b,
                         common.Volume))
-
-                intersection_object = app.activeDocument().addObject(
+                colli_max = common.Volume if common.Volume > colli_max else colli_max
+                if not colli_grp: # create group if it doesn't already exist
+                    colli_grp = doc.addObject("App::DocumentObjectGroup","Collisions")
+                intersection_object = doc.addObject(
                     'Part::Feature')
-                intersection_object.Label = 'Common ({} - {})'.format(
+                intersection_object.Label = '{} - {}'.format(
                     label_a, label_b)
                 intersection_object.Shape = common
                 intersection_object.ViewObject.ShapeColor = (1.0, 0.0, 0.0, 1.0)
-                object_a.ViewObject.Transparency = 80
-                object_b.ViewObject.Transparency = 80
+                colli_grp.addObject(intersection_object)
+            # if no collision, just inform user
             else:
                 app.Console.PrintMessage(
                     'No intersection between {} and {}\n'.format(
                         label_a,
                         label_b))
+
+    # if collisions have been found, commit the undo transaction and
+    # give summary (count + max value) to user
+    if colli_grp:
+        doc.commitTransaction()
+        app.Console.PrintWarning(
+            '{} collision(s) found between selected objects\nMaximum collision : {} mm3\n'.format(
+                len(colli_grp.Group),
+                colli_max))
+        doc.recompute()
+    # if no collision has been found, just inform the user about it
+    else:
+        doc.abortTransaction()
+        app.Console.PrintWarning('No collision found between selected objects\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 This commit brings several improvements to HighlightCommon macro
 * Remove 'error_dialog()' function that was used only once while not helping readibility
 * Store ActiveDocument in a variable at macro launch in case active doc may change during run
 * Store collision shapes in a group 'Collisions' to ease further deleting/hiding/...
 * Add Undo transactions managements so user can correctly undo macro effects
 * Skip object (A or B) processing if it has no volume (eg. a sketch)
 * Make all selected objects transparent because they can prevent collision visualization
 * Print summary message at the end of the analysis (warning style)

- [X] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [X] Your macro has a [Description](../README.md#macro-description) in its header.   
- [X] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  **Wiki to be updated if merged**
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [X] Commit message is titled in the following way `[MacroName] Short description`.
