### PR TITLE
[SketcherOffset] Include support for LinkStage3

### DIFF
--- a/Sketcher/SketcherOffset.FCMacro
+++ b/Sketcher/SketcherOffset.FCMacro
@@ -13,6 +13,7 @@ from PySide import QtGui
 from pivy.coin import *
 if App.Version()[1].find('18') == 0: import DraftTrackers, Draft
 if App.Version()[1].find('19') == 0: import draftguitools.gui_trackers as DraftTrackers
+if App.Version()[5].find('LinkStage3') == 0: import draftguitools.gui_trackers as DraftTrackers
 import re, math
 """
 This macro creates a line chain parallel to an existing one.


### PR DESCRIPTION
Included a line that adds support for LinkStage3 branch of FreeCAD, as LinkStage3 does not use 0.18 or 0.19 in its version description.

Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [x] Please check this box if you're not submitting a new macro.   
- [ ] Are you submitting a new macro ?  
- [ ] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [ ] Your macro has a [Description](../README.md#macro-description) in its header.  
- [ ] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).  
- [ ] Your macro is named [appropriately](../README.md#macro-name-specifics).  
- [ ] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.  
- [ ] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [ ] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
