### PR TITLE
Some version of freecad gives error because of pysideuic module

### DIFF
--- a/FEM/FemAnimateModeShapes.FCMacro
+++ b/FEM/FemAnimateModeShapes.FCMacro
@@ -73,12 +73,9 @@ class FemAnimateModeShapes():
                                     'fem_animate_mode_shapes.ui')
         self.inc = 1  # TODO: find a better name and use.
 
-        f, w = gui.PySideUic.loadUiType(self.ui_file)
-        self.form = f()
-        self.widget = w()
-        self.form.setupUi(self.widget)
-        self.widget.show()
+        self.form  = gui.PySideUic.loadUi(self.ui_file)
         self._connect_widgets()
+        self.form.show()
         self.box = self._message_box()
 
     def _connect_widgets(self):


### PR DESCRIPTION
Instead of loadUiType, only used loadUi.

Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [ ] Please check this box if you're not submitting a new macro.   
- [ ] Are you submitting a new macro ?  
- [ ] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [ ] Your macro has a [Description](../README.md#macro-description) in its header.  
- [ ] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).  
- [ ] Your macro is named [appropriately](../README.md#macro-name-specifics).  
- [ ] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.  
- [ ] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [ ] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
