### PR TITLE
[TD]add macro to migrate v018 drawings to v019

### DIFF
--- a/TechDraw/TechDrawMigrateFromv018.FCMacro
+++ b/TechDraw/TechDrawMigrateFromv018.FCMacro
@@ -24,20 +24,29 @@
 # ***************************************************************************
 """Migrates drawings made in FreeCAD v0.18 to v0.19."""
 
-__title__ = "fixRotation"
-__author__ = "WandeererFan"
-__url__ = "http://www.freecadweb.org/index.html"
-__version__ = "00.01"
-__date__ = "2022/02/26"
+__Name__ = 'TechDrawMigrateFromv018'
+__Comment__ = 'Convert v018 Rotation property to v019'
+__Author__ = 'WandererFan'
+__Version__ = '0.1.0'
+__License__ = 'CC-BY-3.0'
+__Web__ = 'http://www.freecadweb.org/'
+__Wiki__ = 'http://www.freecadweb.org/wiki/Macro_TechDrawViewSet'
+__Icon__ = ''
+__Help__ = 'Open a v018 file in v019, execute'
+__Status__ = 'Alpha'
+__Requires__ = ''
+__Communication__ = 'https://github.com/FreeCAD/FreeCAD-macros/issues/'
+__Files__ = ''
+
 
 # convert v0.18 Rotation values to v0.19 
 
+import FreeCAD as App
 import TechDraw
 
-def fixRotation():
-    increment = App.Units.Degree
-    increment.Value = 270
-    for obj in FreeCAD.ActiveDocument.Objects:
+def TechDrawMigrateFromv018():
+    increment = App.Units.Quantity(270, App.Units.Unit("deg"))
+    for obj in App.ActiveDocument.Objects:
         if obj.isDerivedFrom("TechDraw::DrawViewSection"):
             if obj.Rotation != 0.0:
                 obj.Rotation = obj.Rotation + increment
@@ -52,6 +61,6 @@ def fixRotation():
 
 
 if __name__ == '__main__':
-    fixRotation()
-    FreeCAD.ActiveDocument.recompute()
+    TechDrawMigrateFromv018()
+    App.ActiveDocument.recompute()
 

--- a/TechDraw/v018v019Migration.py
+++ b/TechDraw/v018v019Migration.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2022 - Wanderer Fan <wandererfan@gmail.com>             *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Migrates drawings made in FreeCAD v0.18 to v0.19."""
+
+__title__ = "fixRotation"
+__author__ = "WandeererFan"
+__url__ = "http://www.freecadweb.org/index.html"
+__version__ = "00.01"
+__date__ = "2022/02/26"
+
+# convert v0.18 Rotation values to v0.19 
+
+import TechDraw
+
+def fixRotation():
+    increment = App.Units.Degree
+    increment.Value = 270
+    for obj in FreeCAD.ActiveDocument.Objects:
+        if obj.isDerivedFrom("TechDraw::DrawViewSection"):
+            if obj.Rotation != 0.0:
+                obj.Rotation = obj.Rotation + increment
+                obj.touch()
+            for inObj in obj.InList:
+                if obj.isDerivedFrom("TechDraw::DrawViewDimension"):
+                    inObj.touch()
+        elif obj.isDerivedFrom("TechDraw::DrawViewPart"):
+            if obj.Rotation != 0.0:
+                obj.Rotation = -obj.Rotation
+                obj.touch()
+
+
+if __name__ == '__main__':
+    fixRotation()
+    FreeCAD.ActiveDocument.recompute()
+


### PR DESCRIPTION
This PR adds a macro to convert v018 Rotation property values to the equivalent in v019.

Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [ ] Please check this box if you're not submitting a new macro.   
- [ ] Are you submitting a new macro ?  
- [ ] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [ ] Your macro has a [Description](../README.md#macro-description) in its header.  
- [ ] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).  
- [ ] Your macro is named [appropriately](../README.md#macro-name-specifics).  
- [ ] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.  
- [ ] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [ ] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
