### PR TITLE
Optimized and Added New Features to the HoneyCombSolid Macro

### DIFF
--- a/ParametricObjectCreation/HoneycombSolid.FCMacro
+++ b/ParametricObjectCreation/HoneycombSolid.FCMacro
@@ -7,7 +7,7 @@ HoneycombSolid --> Honeycomb solid creator.
 __Name__ = 'HoneycombSolid'
 __Comment__ = 'Macro to create a Honeycomb solid'
 __Author__ = "Christian González Di Antonio <christiangda@gmail.com>"
-__Version__ = 'v1.1.3'
+__Version__ = 'v1.2.0'
 __License__ = 'LGPL-2.0-or-later'
 __Web__ = 'https://github.com/christiangda/FreeCAD-macros-HoneycombSolid'
 __Wiki__ = 'https://github.com/christiangda/FreeCAD-macros-HoneycombSolid/blob/main/README.md'

--- a/ParametricObjectCreation/honeycomb_solid/honeycomb_solid.py
+++ b/ParametricObjectCreation/honeycomb_solid/honeycomb_solid.py
@@ -37,10 +37,6 @@ class HoneycombSolid:
             "App::PropertyBool", "UseContainer", "Walls", "Invert the shape"
         ).UseContainer = False
 
-        obj.addProperty(
-            "App::PropertyBool", "UseNewAlgorithm", "Walls", "Use the new algorithm"
-        ).UseNewAlgorithm = True
-
         obj.Proxy = self
 
         self.Type = "HoneycombSolid"
@@ -52,112 +48,7 @@ class HoneycombSolid:
         pass
 
     def execute(self, fp):
-        """Callback when doing a recomputation."""
-        log_time_start = time.time()
-        algorithm_version = "new"
-        if fp.UseNewAlgorithm:
-            self.execute_new(fp)
-        else:
-            algorithm_version = "old"
-            self.execute_old(fp)
-
-        log_time_end = time.time()
-        app.Console.PrintMessage(
-            f"Honeycomb ({algorithm_version}) calculated in: "
-            f"{log_time_end - log_time_start:0.3f} sec\n"
-        )
-
-    def execute_old(self, fp):
-        """Callback when doing a recomputation."""
-        length = fp.Length
-        width = fp.Width
-        height = fp.Height
-        radius = fp.Circumradius
-        thickness = fp.Thickness
-
-        edges = 6
-
-        # Container box, used to cut the polygon array.
-        container = Part.makeBox(length, width, height)
-
-        ###############################################################
-        # Create the first polygon.
-        m = app.Matrix()
-        edges_angle = math.radians(360.0 / edges)
-        m.rotateZ(edges_angle)
-        v = app.Vector(radius, 0.0, 0.0)
-
-        figure = []
-        for _ in range(edges):
-            figure.append(v)
-            v = m.multiply(v)
-        figure.append(v)
-        polygon = Part.makePolygon(figure)
-
-        # Move it to the center of the container box.
-        polygon.translate(app.Vector(length / 2.0, width / 2.0, 0.0))
-
-        # Create a face for the first polygon.
-        f1 = Part.Face([polygon])
-
-        #######################################################################
-        # Create copies of polygon using radial pattern.
-
-        # Calculate how many circunferences need to cover the maximum
-        # length of the container box.
-        n_cols = math.ceil((length / (radius + thickness) / 2.0))
-        n_rows = math.ceil((width / (radius + thickness) / 2.0) + 3.0)
-        # app.Console.PrintMessage("n_cols: " + str(n_cols) + " n_rows: " + str(n_rows) + "\n")
-
-        # To store all the polygon faces.
-        e_faces = []
-        # Add the first one created before.
-        e_faces.append(f1)
-
-        # Iterate over each imaginary circle which circunference contains the
-        # center of the polygon circle.
-        def append_face(x_delta, y_delta):
-            x_origin = column * x_delta
-            y_origin = row * y_delta
-
-            delta_x_y = app.Vector(x_origin, y_origin, 0.0)
-
-            polygon_copy = polygon.copy()
-            polygon_copy.translate(delta_x_y)
-            fn = Part.Face([polygon_copy])
-            e_faces.append(fn)
-
-        for column in range(-n_cols, n_cols):
-            for row in range(-n_rows, n_rows):
-                centers_distance = thickness + 2.0 * radius * math.sin(edges_angle)
-                x_delta = centers_distance * math.sin(edges_angle)
-                if (column == 0) and (row == 0):
-                    continue
-                if column % 2 != 0:
-                    # Odd column.
-                    if row % 2 != 0:
-                        # Odd row.
-                        y_delta = centers_distance * math.cos(edges_angle)
-                        append_face(x_delta, y_delta)
-                else:
-                    # Even column.
-                    if (row <= (n_rows / 2)) and (row >= (-n_rows / 2)):
-                        y_delta = centers_distance
-                        append_face(x_delta, y_delta)
-
-        # Join all the faces.
-        shell = Part.makeShell(e_faces)
-        extruded_polygon = shell.extrude(app.Vector(0.0, 0.0, height))
-
-        # Cut the array of solids using the container box.
-        # Comment it out to see the array of solids.
-        shape = container.cut(extruded_polygon)
-
-        fp.Shape = shape  # Comment out to see the array of solids.
-        # fp.Shape = extruded_polygon  # Uncomment it to see the array of solids.
-
-    def execute_new(self, fp):
-        """the new code"""
+        """The new code."""
         length = float(fp.Length)
         width = float(fp.Width)
         height = float(fp.Height)
@@ -166,7 +57,7 @@ class HoneycombSolid:
         try:
             use_container = fp.UseContainer
         except AttributeError:
-            use_container = True  # Backward compatibilty
+            use_container = True  # Backwards compatibilty
 
         edges = 6
 

--- a/ParametricObjectCreation/honeycomb_solid/honeycomb_solid.py
+++ b/ParametricObjectCreation/honeycomb_solid/honeycomb_solid.py
@@ -64,7 +64,7 @@ class HoneycombSolid:
         log_time_end = time.time()
         FreeCAD.Console.PrintMessage(
             f"Honeycomb ({algorithm_version}) calculated in: "
-            f"{log_time_end - log_time_start:0.3f} sec"
+            f"{log_time_end - log_time_start:0.3f} sec\n"
         )
 
     def execute_old(self, fp):

--- a/ParametricObjectCreation/honeycomb_solid/honeycomb_solid.py
+++ b/ParametricObjectCreation/honeycomb_solid/honeycomb_solid.py
@@ -5,7 +5,7 @@ HoneycombSolid --> Honeycomb solid creator.
 
 import math
 import time
-import FreeCAD
+import FreeCAD as app
 import Part
 
 
@@ -48,7 +48,7 @@ class HoneycombSolid:
 
     def onChanged(self, fp, prop):
         """Callback on changed property."""
-        # FreeCAD.Console.PrintMessage("Change property: " + str(prop) + "\n")
+        # app.Console.PrintMessage("Change property: " + str(prop) + "\n")
         pass
 
     def execute(self, fp):
@@ -62,7 +62,7 @@ class HoneycombSolid:
             self.execute_old(fp)
 
         log_time_end = time.time()
-        FreeCAD.Console.PrintMessage(
+        app.Console.PrintMessage(
             f"Honeycomb ({algorithm_version}) calculated in: "
             f"{log_time_end - log_time_start:0.3f} sec\n"
         )
@@ -82,10 +82,10 @@ class HoneycombSolid:
 
         ###############################################################
         # Create the first polygon.
-        m = FreeCAD.Matrix()
+        m = app.Matrix()
         edges_angle = math.radians(360.0 / edges)
         m.rotateZ(edges_angle)
-        v = FreeCAD.Vector(radius, 0.0, 0.0)
+        v = app.Vector(radius, 0.0, 0.0)
 
         figure = []
         for _ in range(edges):
@@ -95,7 +95,7 @@ class HoneycombSolid:
         polygon = Part.makePolygon(figure)
 
         # Move it to the center of the container box.
-        polygon.translate(FreeCAD.Vector(length / 2.0, width / 2.0, 0.0))
+        polygon.translate(app.Vector(length / 2.0, width / 2.0, 0.0))
 
         # Create a face for the first polygon.
         f1 = Part.Face([polygon])
@@ -107,7 +107,7 @@ class HoneycombSolid:
         # length of the container box.
         n_cols = math.ceil((length / (radius + thickness) / 2.0))
         n_rows = math.ceil((width / (radius + thickness) / 2.0) + 3.0)
-        # FreeCAD.Console.PrintMessage("n_cols: " + str(n_cols) + " n_rows: " + str(n_rows) + "\n")
+        # app.Console.PrintMessage("n_cols: " + str(n_cols) + " n_rows: " + str(n_rows) + "\n")
 
         # To store all the polygon faces.
         e_faces = []
@@ -120,7 +120,7 @@ class HoneycombSolid:
             x_origin = column * x_delta
             y_origin = row * y_delta
 
-            delta_x_y = FreeCAD.Vector(x_origin, y_origin, 0.0)
+            delta_x_y = app.Vector(x_origin, y_origin, 0.0)
 
             polygon_copy = polygon.copy()
             polygon_copy.translate(delta_x_y)
@@ -147,7 +147,7 @@ class HoneycombSolid:
 
         # Join all the faces.
         shell = Part.makeShell(e_faces)
-        extruded_polygon = shell.extrude(FreeCAD.Vector(0.0, 0.0, height))
+        extruded_polygon = shell.extrude(app.Vector(0.0, 0.0, height))
 
         # Cut the array of solids using the container box.
         # Comment it out to see the array of solids.
@@ -171,10 +171,10 @@ class HoneycombSolid:
         edges = 6
 
         # Create the first polygon.
-        m = FreeCAD.Matrix()
+        m = app.Matrix()
         edges_angle = math.radians(360.0 / edges)
         m.rotateZ(edges_angle)
-        v = FreeCAD.Vector(radius, 0.0, 0.0)
+        v = app.Vector(radius, 0.0, 0.0)
 
         figure = []
         for _ in range(edges):
@@ -187,7 +187,7 @@ class HoneycombSolid:
         half_length = length / 2.0
         half_width = width / 2.0
 
-        offset_vector = FreeCAD.Vector(half_length, half_width, 0.0)
+        offset_vector = app.Vector(half_length, half_width, 0.0)
         polygon.translate(offset_vector)
 
         # Calculate how many circumferences need to cover the maximum
@@ -211,11 +211,11 @@ class HoneycombSolid:
         )
         n_cols = math.ceil((length / 2 + circum_radius) / (x_delta)) * 2 - 1
 
-        # FreeCAD.Console.PrintMessage(f"n_rows: {n_rows}")
-        # FreeCAD.Console.PrintMessage(f"n_cols: {n_cols}")
-        # FreeCAD.Console.PrintMessage("circumradius (outer): {:0.3f}".format(circum_radius))
+        # app.Console.PrintMessage(f"n_rows: {n_rows}")
+        # app.Console.PrintMessage(f"n_cols: {n_cols}")
+        # app.Console.PrintMessage("circumradius (outer): {:0.3f}".format(circum_radius))
 
-        delta_x_y = FreeCAD.Vector(0, 0, 0)
+        delta_x_y = app.Vector(0, 0, 0)
 
         # To store all the polygon faces.
         min_col_range = int(math.ceil(-n_cols / 2))
@@ -237,7 +237,7 @@ class HoneycombSolid:
 
         # Join all the faces.
         shell = Part.makeShell(e_faces)
-        extruded_poly = shell.extrude(FreeCAD.Vector(0.0, 0.0, height))
+        extruded_poly = shell.extrude(app.Vector(0.0, 0.0, height))
 
         if use_container:
             # Cut the array of solids using the container box.
@@ -306,7 +306,7 @@ class ViewProviderHoneycombSolid:
 
     def onChanged(self, vp, prop):
         """Print the name of the property that has changed."""
-        # FreeCAD.Console.PrintMessage("Change property: " + str(prop) + "\n")
+        # app.Console.PrintMessage("Change property: " + str(prop) + "\n")
         pass
 
     def getIcon(self):
@@ -412,10 +412,10 @@ class ViewProviderHoneycombSolid:
 
 
 def makeHoneycombSolid(version):
-    doc = FreeCAD.activeDocument()
+    doc = app.activeDocument()
 
     if doc is None:
-        doc = FreeCAD.newDocument()
+        doc = app.newDocument()
 
     obj = doc.addObject("Part::FeaturePython", "HoneycombSolid")
     HoneycombSolid(obj, version)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [X] Please check this box if you're not submitting a new macro.   
- [ ] Are you submitting a new macro ?  
- [x] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [x] Your macro has a [Description](../README.md#macro-description) in its header.  
- [x] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).  
- [x] Your macro is named [appropriately](../README.md#macro-name-specifics).  
- [x] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.  
- [x] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [ ] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Hi this is an update to the HoneyCombSolid Macro. I have done fixes to the general approach, added new features and optimized the code.

- Fixes:
  - For very big sizes the old code was not generating proper geometry.
    ![image](https://user-images.githubusercontent.com/1786804/195150192-41b89778-41e8-417d-bd00-af377d1118b9.png)
- New Features:
  - The old approach was doing an unnecessary boolean operation and it was not possible to only get the hexagonal shapes:
    ![image](https://user-images.githubusercontent.com/1786804/195150941-ecbaa269-9fdd-46d2-b53f-e479e5d20437.png)
  - The old one forces the user to generate an unnecessarily big hexagon grid if the user requires a custom outline. New approach allows the hexagon shapes to be combined with a custom shape.
  - This approach eliminates the unnecessary boolean operation and makes it work 4.5-5x faster.
  - The user can specify the usage of the container geometry with the ``UseContainer`` parameter.
  - The user can still switch back to the old algorithm by setting the ``UseNewAlgorithm`` parameter to False:
    ![image](https://user-images.githubusercontent.com/1786804/195151935-82552d91-455e-4849-95b0-8cae76d17e2f.png)
- Optimizations:
  - As explained above not using a container is 4.5x to 5x faster:
    ![image](https://user-images.githubusercontent.com/1786804/195152201-b700b5fc-43a3-480f-af79-a84f82313e69.png)
    ![image](https://user-images.githubusercontent.com/1786804/195153528-8e2058c4-844d-48b3-b475-8b64ab3f17e2.png)
   - And the new algorithm is 20% faster if a container is used: 
    ![image](https://user-images.githubusercontent.com/1786804/195152568-62dfd8d4-956e-461d-85b9-6eaf605cf5c0.png)
  - The output matches the previous approach:
    ![image](https://user-images.githubusercontent.com/1786804/195152894-5a7840cd-3350-4644-81c8-b3cea11059fa.png)



