### PR TITLE
[HighLightCommon] correct condition for warning

### DIFF
--- a/Utility/HighlightCommon.FCMacro
+++ b/Utility/HighlightCommon.FCMacro
@@ -134,7 +134,7 @@ def main():
     else:
         # If no collision has been found, just inform the user about it.
         doc.abortTransaction()
-        if len(object_list) == 2:
+        if len(object_list) >= 2:
             app.Console.PrintWarning('No collision found between selected objects\n')
         else:
             app.Console.PrintWarning('No suitable objects selected, select at least two objects\n')


### PR DESCRIPTION
Warning is shown only for selections of less than two relevant objects, not for more or less than two.

Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [x] Please check this box if you're not submitting a new macro.   
- [ ] Are you submitting a new macro ?  
- [ ] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [ ] Your macro has a [Description](../README.md#macro-description) in its header.  
- [ ] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).  
- [ ] Your macro is named [appropriately](../README.md#macro-name-specifics).  
- [ ] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.  
- [ ] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [x] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
