### PR TITLE
[ObjectsToPython] Code optimized read-only properties in FC 1.0

### DIFF
--- a/ImportExport/ObjectsToPython.FCMacro
+++ b/ImportExport/ObjectsToPython.FCMacro
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__Version__ = '0.7.4'
+__Version__ = '0.7.6'
 __Date__ = '2025-01-09'
 __License__ = 'LGPL-3.0-or-later'
 __Web__ = ''

--- a/ImportExport/ObjectsToPython.FCMacro
+++ b/ImportExport/ObjectsToPython.FCMacro
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-__Version__ = '0.7.3'
-__Date__ = '2024-03-16'
+__Version__ = '0.7.4'
+__Date__ = '2025-01-09'
 __License__ = 'LGPL-3.0-or-later'
 __Web__ = ''
 __Wiki__ = 'README.md'

--- a/ImportExport/ObjectsToPython.FCMacro
+++ b/ImportExport/ObjectsToPython.FCMacro
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-__Version__ = '0.7.5'
-__Date__ = '2025-01-08'
+__Version__ = '0.7.3'
+__Date__ = '2024-03-16'
 __License__ = 'LGPL-3.0-or-later'
 __Web__ = ''
 __Wiki__ = 'README.md'
@@ -141,21 +141,11 @@ def addObject(doc, obj, objectlist):
                   defaultobj.ViewObject, [])
     doc.removeObject(obj.Name + 'Default')
 
-
 def addProperties(obj, objname, refobj, objectlist):
-    skipProperties = [
-            'AddSubShape',
-            'FullyConstrained',
-            'InternalShape',
-            'Label',
-            'MaterialName',
-            'Proxy',
-            'Shape',
-            'ShapeAppearance',
-            'ShapeMaterial',
-            'SuppressedShape',
-            'VisualLayerList',
-    ]
+    skipProperties = ['Label', 'Shape', 'Proxy',
+                      'AddSubShape', 'FullyConstrained', 'VisualLayerList',
+                     'InternalShape', 'ShapeMaterial', 'ShapeAppearance', 'MaterialName',
+                     'SuppressedShape']
 
     skipObjProp = [
         ('Sketcher::SketchObject', 'Geometry'),
@@ -165,22 +155,17 @@ def addProperties(obj, objname, refobj, objectlist):
     ]
 
     # Cf. https://github.com/FreeCAD/FreeCAD/blob/278ce803907ef72548d7ac761613038ac435c481/src/App/Property.h#L60
-    statusdict = {
-            'PropStaticBegin': 21,
-            'PropDynamic': 21,
-            'PropNoPersist': 22,
-            'PropNoRecompute': 23,
-            'PropReadOnly': 24,
-            'PropTransient': 25,
-            'PropHidden': 26,
-            'PropOutput': 27,
-            'PropStaticEnd': 28,
-    }
+    statuslist = [
+            'Immutable', 1,
+            'ReadOnly', 2,
+            'PropReadOnly', 24,
+            'PropOutput', 27, 
+    ]
 
-    def dontWriteProperty(obj, propname, statuslist):
+    def propIsReadonly(obj, propname):
         statusnums = obj.getPropertyStatus(propname)
         for status in statuslist:
-            if statusdict[status] in statusnums:
+            if status in statusnums:
                 return True
         return False
 
@@ -192,9 +177,9 @@ def addProperties(obj, objname, refobj, objectlist):
         addSketch(obj, objname)
 
     for propname in obj.PropertiesList:
-        if ((propname not in skipProperties)
-                and ((obj.TypeId, propname) not in skipObjProp)
-                and (not dontWriteProperty(obj, propname, ["PropReadOnly", "PropOutput"]))):
+        if (propname not in skipProperties)\
+            and ((obj.TypeId, propname) not in skipObjProp)\
+            and not propIsReadonly(obj, propname):
             prop = obj.getPropertyByName(propname)
             val = objectToText(prop, objectlist)
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [x] Please check this box if you're not submitting a new macro.   
- [ ] Are you submitting a new macro ?  
- [ ] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?  
- [ ] Your macro has a [Description](../README.md#macro-description) in its header.  
- [ ] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).  
- [ ] Your macro is named [appropriately](../README.md#macro-name-specifics).  
- [ ] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.  
- [ ] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.  
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)  
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)  
- [ ] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
