### PR TITLE
[CenterOfMass] Several fixes

### DIFF
--- a/Information/CenterOfMass.FCMacro
+++ b/Information/CenterOfMass.FCMacro
@@ -26,8 +26,8 @@
 __Name__ = 'CenterOfMass'
 __Comment__ = 'Compute and show the center of mass for multiple solids'
 __Author__ = 'chupins, s-quirin, farahats9'
-__Version__ = '0.8.2'
-__Date__ = '2025-01-20'
+__Version__ = '0.8.3'
+__Date__ = '2025-01-21'
 __License__ = 'LGPL-3.0-or-later'
 __Web__ = 'https://forum.freecad.org/viewtopic.php?f=24&t=31883'
 __Wiki__ = 'https://wiki.freecad.org/Macro_CenterOfMass'
@@ -68,6 +68,7 @@ COLOR_SATURAT = app.ParamGet(MACRO_SETTINGS).GetUnsigned('Color saturation', 80)
 COLORMAP_USER = app.ParamGet(MACRO_SETTINGS).GetString('Matplotlib colormap', 'Spectral_r')
 GUI_FONT_SIZE = app.ParamGet('User parameter:BaseApp/Preferences/Editor').GetInt('FontSize', 10)
 GUI_ICON_SIZE = app.ParamGet('User parameter:BaseApp/Preferences/General').GetInt('ToolbarIconSize', 24)
+GUI_THEME = app.ParamGet('User parameter:BaseApp/Preferences/MainWindow').GetString('Theme', '')
 
 MATERIAL_SETTINGS = app.ParamGet('User parameter:BaseApp/Preferences/Mod/Material/Resources')
 USE_BUILT_IN_MATERIALS = MATERIAL_SETTINGS.GetBool('UseBuiltInMaterials', True)
@@ -613,6 +614,8 @@ class CenterofmassWidget(QtGui.QWidget):
             # Reset label highlighting
             for label in self.found_labels:
                 label.setFrameStyle(QtGui.QFrame.NoFrame)
+                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                    label.setStyleSheet('')
             self.found_labels = []
         if text == '':
             self.scroll.ensureWidgetVisible(self.solids[0].label)
@@ -621,6 +624,8 @@ class CenterofmassWidget(QtGui.QWidget):
             if text.lower() in selfsol.label.text().lower():
                 self.found_labels.append(selfsol.label)
                 selfsol.label.setFrameShape(QtGui.QFrame.StyledPanel)
+                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                    selfsol.label.setStyleSheet('QFrame {border: 1px solid #B477FF}')
         if self.found_labels:
             self.scroll.ensureWidgetVisible(self.found_labels[0])
 
@@ -1184,6 +1189,8 @@ class CenterofmassWidget(QtGui.QWidget):
                 if COLOR_SPHERES and self.changeRadius.isEnabled():
                     self.set_object_color('CoM_' + g_sel[sol].Name, selfsol.orgColorFC)
                 selfsol.spinDens.setPalette(QtGui.QPalette())    # reset to normal
+                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                    selfsol.spinDens.setStyleSheet('')
 
     def on_comboColormap_changed(self, newText):
         if self.checkColorify.isChecked():
@@ -1202,8 +1209,12 @@ class CenterofmassWidget(QtGui.QWidget):
     def coloring(self):
         cmName = self.comboColormap.currentText()
         if cmName != 'Traffic':
-            import matplotlib.cm
-            cm = matplotlib.cm.get_cmap(cmName)
+            if FREECAD_VERSION < 0.22:
+                import matplotlib.cm
+                cm = matplotlib.cm.get_cmap(cmName)
+            else:
+                import matplotlib
+                cm = matplotlib.colormaps[cmName]
         densities = [selfsol.spinDens.value() for selfsol in self.solids]
         maxD = max(densities)
         minD = min([i_ for i_ in densities if i_ != 0])    # min without zeros
@@ -1211,6 +1222,8 @@ class CenterofmassWidget(QtGui.QWidget):
             if self.masses[sol] == 0:
                 self.set_object_color(g_sel[sol].Name, selfsol.orgColorFC)
                 selfsol.spinDens.setPalette(QtGui.QPalette())    # reset to normal
+                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                    selfsol.spinDens.setStyleSheet('')
                 continue
             if maxD == minD:
                 drel = 0    # default to low color
@@ -1235,7 +1248,13 @@ class CenterofmassWidget(QtGui.QWidget):
                 c = c/12.92 if c <= 0.04045 else math.pow((c+0.055)/1.055, 2.4)
             if 0.2126*lum[0] + 0.7152*lum[1] + 0.0722*lum[2] < 0.5:
                 pal.setColor(QtGui.QPalette.Text, QtCore.Qt.white)
+                textColor = 'white'
+            else:
+                textColor = 'black'
             selfsol.spinDens.setPalette(pal)
+            if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                selfsol.spinDens.setStyleSheet(
+                    'QDoubleSpinBox {background-color: %s; color: %s}' % (color.name(), textColor))
 
     def on_pushButton_toPreferences(self):
         gui.runCommand('Std_DlgParameter', 0)

--- a/Information/CenterOfMass.FCMacro
+++ b/Information/CenterOfMass.FCMacro
@@ -27,7 +27,7 @@ __Name__ = 'CenterOfMass'
 __Comment__ = 'Compute and show the center of mass for multiple solids'
 __Author__ = 'chupins, s-quirin, farahats9'
 __Version__ = '0.8.2'
-__Date__ = '2025-01-16'
+__Date__ = '2025-01-20'
 __License__ = 'LGPL-3.0-or-later'
 __Web__ = 'https://forum.freecad.org/viewtopic.php?f=24&t=31883'
 __Wiki__ = 'https://wiki.freecad.org/Macro_CenterOfMass'
@@ -377,7 +377,10 @@ class CenterofmassWidget(QtGui.QWidget):
         self.load_materials()    # load material cards
         solidGroupBox = QtGui.QWidget()
         self.solidLayout = QtGui.QGridLayout(solidGroupBox)
+        margin = self.solidLayout.contentsMargins()
+        self.solidLayout.setContentsMargins(0, 0, margin.right(), margin.bottom()/2)
         self.scroll = QtGui.QScrollArea()
+        self.scroll.setFrameShape(QtGui.QFrame.NoFrame)    # remove frame shadow in old themes
         self.scroll.setWidget(solidGroupBox)
         self.scroll.setWidgetResizable(True)
         self.found_labels = []    # for search
@@ -403,31 +406,26 @@ class CenterofmassWidget(QtGui.QWidget):
         newSelection = QtGui.QPushButton('New')
         newSelection.setToolTip('Get solids from selection')
         newSelection.setIcon(QtGui.QIcon(':/icons/LinkSelect.svg'))
-        newSelection.setIconSize(g_icon_size)
         newSelection.clicked.connect(self.on_pushButton_newSelection)
 
         update = QtGui.QPushButton('Update')
         update.setToolTip('Update solids from document')
         update.setIcon(QtGui.QIcon(':/icons/view-refresh.svg'))
-        update.setIconSize(g_icon_size)
         update.clicked.connect(self.on_pushButton_update)
 
         save = QtGui.QPushButton('Save')
         save.setToolTip('Copy material property to your document model data')
         save.setIcon(QtGui.QIcon(':/icons/Std_MergeProjects.svg'))
-        save.setIconSize(g_icon_size)
         save.clicked.connect(self.on_pushButton_Save)
 
         export = QtGui.QPushButton('Export')
         export.setToolTip('Export values to a .csv file')
         export.setIcon(QtGui.QIcon(':/icons/Std_Export.svg'))
-        export.setIconSize(g_icon_size)
         export.clicked.connect(self.on_pushButton_Export)
 
         readDensities = QtGui.QPushButton('Import')
         readDensities.setToolTip('Import masses, materials or densities from a file')
         readDensities.setIcon(QtGui.QIcon(':/icons/Std_Import.svg'))
-        readDensities.setIconSize(g_icon_size)
         readDensities.clicked.connect(self.on_pushButton_Import)
 
         buttonGroupBox = QtGui.QWidget()
@@ -496,7 +494,9 @@ class CenterofmassWidget(QtGui.QWidget):
         self.com_clipboard.setFlat(True)
         self.com_clipboard.clicked.connect(self.on_pushButton_copyToClipboardCdG)
 
-        axis_labels = [{'label': 'X', 'style': 'color:rgb(255, 0, 0)'}, {'label': 'Y', 'style': 'color:rgb(0, 255, 0)'}, {'label': 'Z', 'style': 'color:rgb(0, 0, 255)'}]
+        axis_labels = [{'label': 'X', 'style': 'color:rgb(255, 0, 0)'},
+                       {'label': 'Y', 'style': 'color:rgb(0, 255, 0)'},
+                       {'label': 'Z', 'style': 'color:rgb(0, 0, 255)'}]
         cdgLayout = QtGui.QHBoxLayout()
         for index, axis in enumerate(axis_labels):
             label_CdG = QtGui.QLabel(axis['label'])
@@ -559,6 +559,7 @@ class CenterofmassWidget(QtGui.QWidget):
 
         self.resultMoI = []
         inertiaLayout = QtGui.QGridLayout()
+        inertiaLayout.setVerticalSpacing(0)    # reduce vertical window size
         for i, axis in enumerate(axis_labels):
             label_row = QtGui.QLabel(axis['label'])
             label_row.setStyleSheet(axis['style'])
@@ -582,6 +583,7 @@ class CenterofmassWidget(QtGui.QWidget):
         inertiaGroupBox.setToolTip('Taken at the center of mass and aligned with global coordinates')
         inertiaGroupBox.setLayout(inertiaLayout)
         layout.addWidget(inertiaGroupBox)
+        layout.addStretch()    # minimize all groupboxes to their necessary vertical size
 
         self.inertia_clipboard = QtGui.QPushButton(QtGui.QIcon(':/icons/edit-copy.svg'), '')
         self.inertia_clipboard.setToolTip(f'Copy to clipboard ({self.unitForI})')
@@ -814,12 +816,13 @@ class CenterofmassWidget(QtGui.QWidget):
             resources.append(Path(app.ConfigGet("UserAppData"), "Material"))
         if USE_MAT_FROM_CUSTOM_DIR and CUSTOM_MAT_DIR:
             resources.append(Path(CUSTOM_MAT_DIR))
-        print('Looking for material cards according to',
-              'User parameter:BaseApp/Preferences/Mod/Material/Resources')
+        app.Console.PrintMessage('Looking for material cards according to ' +
+            'User parameter:BaseApp/Preferences/Mod/Material/Resources' + '\n')
 
         # Read material cards
         for p in resources:
-            print(f'  {p}')    # cards found later with same name will override previous ones
+            app.Console.PrintMessage(f'  {p}' + '\n')
+            # cards found later with same name will override previous ones
             dir_gen = p.rglob('*.FCMat')   # is generator -> use only once
             for f in dir_gen:
                 if f.stem == 'Default':
@@ -1437,7 +1440,7 @@ if __name__ == '__main__':
     elif not app.activeDocument():
         error_message('Open a document first.')
     else:
-        print('Loading ' + __Name__ + ' ' + __Version__ + ' ...')
+        app.Console.PrintMessage(f'Loading {__Name__} {__Version__} ...' + '\n')
         gui.updateGui()
         if DOCKED_WINDOW:
             myWidget = CenterofmassDock()

--- a/Information/CenterOfMass.FCMacro
+++ b/Information/CenterOfMass.FCMacro
@@ -614,7 +614,8 @@ class CenterofmassWidget(QtGui.QWidget):
             # Reset label highlighting
             for label in self.found_labels:
                 label.setFrameStyle(QtGui.QFrame.NoFrame)
-                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                if FREECAD_VERSION > 0.22 and GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:
+                    # BUG if theme non Classic
                     label.setStyleSheet('')
             self.found_labels = []
         if text == '':
@@ -624,7 +625,8 @@ class CenterofmassWidget(QtGui.QWidget):
             if text.lower() in selfsol.label.text().lower():
                 self.found_labels.append(selfsol.label)
                 selfsol.label.setFrameShape(QtGui.QFrame.StyledPanel)
-                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                if FREECAD_VERSION > 0.22 and GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:
+                    # BUG if theme non Classic
                     selfsol.label.setStyleSheet('QFrame {border: 1px solid #B477FF}')
         if self.found_labels:
             self.scroll.ensureWidgetVisible(self.found_labels[0])
@@ -724,8 +726,12 @@ class CenterofmassWidget(QtGui.QWidget):
             vsel.sort(key=sort_selection_by_label)
         else:
             tree = g_main_window.findChild(QtGui.QTreeWidget)
+            if tree.topLevelItem(0) is None:    # FreeCAD > 0.22
+                for t_ in g_main_window.findChildren(QtGui.QTreeWidget):
+                    if t_.topLevelItem(0) is not None:
+                        tree = t_
             iterator = QtGui.QTreeWidgetItemIterator(tree, QtGui.QTreeWidgetItemIterator.Editable)
-            self.tree_list = [i_.value().text(0) for i_ in list(iterator)]
+            self.tree_list = [i_.value().text(0) for i_ in iterator]
             if self.tree_list:
                 vsel.sort(key=sort_selection_by_tree)
             else:
@@ -1189,7 +1195,8 @@ class CenterofmassWidget(QtGui.QWidget):
                 if COLOR_SPHERES and self.changeRadius.isEnabled():
                     self.set_object_color('CoM_' + g_sel[sol].Name, selfsol.orgColorFC)
                 selfsol.spinDens.setPalette(QtGui.QPalette())    # reset to normal
-                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                if FREECAD_VERSION > 0.22 and GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:
+                    # BUG if theme non Classic
                     selfsol.spinDens.setStyleSheet('')
 
     def on_comboColormap_changed(self, newText):
@@ -1222,7 +1229,8 @@ class CenterofmassWidget(QtGui.QWidget):
             if self.masses[sol] == 0:
                 self.set_object_color(g_sel[sol].Name, selfsol.orgColorFC)
                 selfsol.spinDens.setPalette(QtGui.QPalette())    # reset to normal
-                if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+                if FREECAD_VERSION > 0.22 and GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:
+                    # BUG if theme non Classic
                     selfsol.spinDens.setStyleSheet('')
                 continue
             if maxD == minD:
@@ -1252,7 +1260,8 @@ class CenterofmassWidget(QtGui.QWidget):
             else:
                 textColor = 'black'
             selfsol.spinDens.setPalette(pal)
-            if GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:    # BUG: theme non Classic (1.0)
+            if FREECAD_VERSION > 0.22 and GUI_THEME in ['FreeCAD Light', 'FreeCAD Dark']:
+                # BUG if theme non Classic
                 selfsol.spinDens.setStyleSheet(
                     'QDoubleSpinBox {background-color: %s; color: %s}' % (color.name(), textColor))
 

--- a/Information/CenterOfMass.FCMacro
+++ b/Information/CenterOfMass.FCMacro
@@ -26,23 +26,20 @@
 __Name__ = 'CenterOfMass'
 __Comment__ = 'Compute and show the center of mass for multiple solids'
 __Author__ = 'chupins, s-quirin, farahats9'
-__Version__ = '0.8.1'
-__Date__ = '2025-01-10'
+__Version__ = '0.8.2'
+__Date__ = '2025-01-16'
 __License__ = 'LGPL-3.0-or-later'
 __Web__ = 'https://forum.freecad.org/viewtopic.php?f=24&t=31883'
 __Wiki__ = 'https://wiki.freecad.org/Macro_CenterOfMass'
 __Icon__ = 'https://wiki.freecad.org/images/a/a6/Macro_CenterOfMass.svg'
 __Help__ = 'Select one or more bodies and launch'
 __Status__ = 'Alpha'
-__Requires__ = 'FreeCAD >= 0.19'
+__Requires__ = 'FreeCAD >= 0.20'
 __Communication__ = 'https://forum.freecad.org/viewtopic.php?f=24&t=31883'
 __Files__ = ''
 
 # Todo:
 # - error with draft array of meshes (relevant?)
-# - App:Link lacks the .getGlobalPlacement() method and childShapes() do not equal,
-# so .InListRecursive and .OutList is used as a workaround.
-# @realthunder proposes https://forum.freecad.org/viewtopic.php?p=569083#p569083
 # Ideas:
 # - moments of inertia with arrows that allow the user to see the relative magnitudes
 
@@ -82,7 +79,9 @@ CUSTOM_MAT_DIR = MATERIAL_SETTINGS.GetString('CustomMaterialsDir', '')
 WINDOW_WIDTH = int(0.2 * QtGui.QGuiApplication.screens()[0].geometry().width())
 WINDOW_HEIGHT = int(0.5 * QtGui.QGuiApplication.screens()[0].geometry().height())
 
-if float(f'{app.Version()[0]}.{app.Version()[1]}') < 0.21:
+FREECAD_VERSION = float(f'{app.Version()[0]}.{app.Version()[1]}')
+
+if FREECAD_VERSION < 0.21:
     # FreeCAD 0.20 is able to run with Qt 5.9.5 but Qt 5.12 was adopted here
     if QtCore.QLibraryInfo.version() < QtCore.QVersionNumber(5, 12):
         app.Console.PrintWarning('Qt 5.12 or higher is needed to run\n')
@@ -260,7 +259,7 @@ class SolidsWidget():
     def get_object_material(solid):
         """Retrieves material properties, handling PartDesign features correctly."""
         material = None
-        if float(f'{app.Version()[0]}.{app.Version()[1]}') < 0.22:
+        if FREECAD_VERSION < 0.22:
             return material
         if hasattr(solid, "ShapeMaterial"):
             material = solid.ShapeMaterial
@@ -729,7 +728,7 @@ class CenterofmassWidget(QtGui.QWidget):
 
         # create valid objects list (e.g. shapes)
         import Part
-        if float(f'{app.Version()[0]}.{app.Version()[1]}') >= 0.22:
+        if 0.22 <= FREECAD_VERSION < 1.0:
             import UtilsAssembly
         objs = []
         for i_, s_ in enumerate(vsel):
@@ -739,10 +738,12 @@ class CenterofmassWidget(QtGui.QWidget):
                 if callable(getattr(s_, 'getGlobalPlacement', None)):
                     o_.Placement = s_.getGlobalPlacement()
                     # e.g. App::Link has no method getGlobalPlacement
-                elif float(f'{app.Version()[0]}.{app.Version()[1]}') < 0.22:
+                elif FREECAD_VERSION < 0.22:
                     if s_.InList:
                         for it in s_.InListRecursive:
                             o_.Placement = o_.Placement.multiply(it.Placement)
+                elif 0.22 <= FREECAD_VERSION < 1.0:
+                    o_.Placement = UtilsAssembly.getGlobalPlacement(s_)
                 elif s_.TypeId != 'Assembly::JointGroup' or s_.TypeId == 'App::Link':
                     if s_.InList:
                         for it in s_.InListRecursive:
@@ -750,8 +751,6 @@ class CenterofmassWidget(QtGui.QWidget):
                                 o_.Placement = o_.Placement.multiply(it.Placement)
                 elif s_.TypeId == 'Assembly::JointGroup':
                     continue
-                else:
-                    o_.Placement = UtilsAssembly.getGlobalPlacement(s_)
                 objs.append(o_)
             elif hasattr(s_, 'Mesh'):
                 objs.append(s_.Mesh)
@@ -805,7 +804,7 @@ class CenterofmassWidget(QtGui.QWidget):
         import importFCMat
         resources: list[Path] = []
         if USE_BUILT_IN_MATERIALS:
-            if float(f'{app.Version()[0]}.{app.Version()[1]}') < 0.22:
+            if FREECAD_VERSION < 0.22:
                 resources.append(Path(app.getResourceDir(), "Mod", "Material", "StandardMaterial"))
             else:
                 resources.append(Path(
@@ -1276,7 +1275,7 @@ class CenterofmassWidget(QtGui.QWidget):
                 g_sel[sol].Mat_Name = mat_selected
                 # Density
                 if not hasattr(g_sel[sol], 'Mat_Density'):
-                    if float(f'{app.Version()[0]}.{app.Version()[1]}') < 0.22:
+                    if FREECAD_VERSION < 0.22:
                         g_sel[sol].addProperty('App::PropertyString', 'Mat_Density', *tip)
                     else:
                         # 'App::PropertyDensity' available since FreeCAD 0.21


### PR DESCRIPTION
- [x] Please check this box if you're not submitting a new macro. 
---
### Changelog
- **Fix**: FreeCAD#178 by catching the RuntimeError to avoid segfault crash
- **Fix**: FreeCAD#179 by checking for CoM objects and blocking certain operations. You can take the centre of mass of a centre of mass if you move them outside the 'CenterOfMass' group folder in your document
- **Fix**: Reduce the vertical GUI expansion to the necessary minimum [FreeCAD forum post](https://forum.freecad.org/viewtopic.php?p=803708&sid=44ff13264fc5bca425482f70c3b016a5#p803708)
- **Fix**: Coloring of spin boxes and search results in new FreeCAD Light and Dark theme
- **Fix**: 'Could not take over the sorting of the tree view' in FreeCAD 1.0
- **Code**: Improve version handling and updated minimum requirement for FreeCAD version
- **Code**: Replace print by app.Console.PrintMessage
