### PR TITLE
[Export2Slicer] Add parameter for the output folder

### DIFF
--- a/ImportExport/Export2Slicer.FCMacro
+++ b/ImportExport/Export2Slicer.FCMacro
@@ -3,8 +3,8 @@
 
 __Title__ = '3D Print / Slice'
 __Author__ = 'Damian Łoziński'
-__Version__ = '0.4.1'
-__Date__ = '2024-08-28'
+__Version__ = '0.4.2'
+__Date__ = '2025-08-28'
 __Comment__ = 'Export selected objects to amf/stl files and open them in slicing program'
 __Web__ = 'https://github.com/dlozinski/FreeCAD-macros/blob/doc/ImportExport/ExportToSlicer.md'
 __Wiki__ = ''
@@ -29,6 +29,7 @@ import MeshPart
 MACRO_PARAMS = app.ParamGet('User parameter:BaseApp/Preferences/Macros/Export2Slicer')
 DEFAULT_SLICER_CMD = '"/Applications/Original Prusa Drivers/PrusaSlicer.app/Contents/MacOS/PrusaSlicer" --single-instance "{file}"'
 DEFAULT_OUTPUT_FORMAT = 'amf'
+DEFAULT_OUTPUT_FOLDER = ''
 DEFAULT_ANGULAR_DEFLECTION = 0.07
 
 
@@ -50,6 +51,7 @@ def get_float_param(name, default):
 
 slicer_cmd = get_string_param('SlicerCommand', DEFAULT_SLICER_CMD)
 output_format = get_string_param('OutputFormat', DEFAULT_OUTPUT_FORMAT)
+output_folder = get_string_param('OutputFolder', DEFAULT_OUTPUT_FOLDER)
 angular_deflection = get_float_param('AngularDeflection', DEFAULT_ANGULAR_DEFLECTION)
 
 
@@ -60,7 +62,7 @@ def escape(text):
 def get_mesh_filename(doc_filename, mesh_names):
     """Returns valid filename for temporary mesh file."""
     if doc_filename:
-        dirname = os.path.dirname(doc_filename)
+        dirname = output_folder if output_folder and os.path.isdir(output_folder) else os.path.dirname(doc_filename)
         filename = (
             os.path.basename(doc_filename).partition('.')[0]
             + '-'


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD-macros!
To integrate your macro please make sure the following steps are complete:

- [x] Please check this box if you're not submitting a new macro.
- [ ] Are you submitting a new macro ?
- [ ] Have you followed the ['How to submit a macro'](../README.md#how-to-submit-a-macro) section of the README.md ?
- [ ] Your macro has a [Description](../README.md#macro-description) in its header.
- [ ] Your macro has a [CamelCase name](../README.md#camelcase-macro-name).
- [ ] Your macro is named [appropriately](../README.md#macro-name-specifics).
- [ ] Your macro contains a [Metadata section](../README.md#macro-metadata) that immediately follows the header description.
- [ ] Your macro is Python3/Qt5 compliant and tested on the latest FreeCAD stable and development releases.
- [ ] You're including documentation on how your macro works (bonus: screenshots and/or video on the Wiki)
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message is titled in the following way `[MacroName] Short description`.
- [ ] Optional, write or update the changelog in the macro, from latest to oldest.

And please remember to update the Wiki with the features added or changed once this PR is merged.
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

This pull request adds a parameter to the `Export2Slicer` macro to store the outputted `amf` files in another folder.
I did this because I wanted to keep my project folders a bit cleaner and not have them cluttered with export files.